### PR TITLE
Improve pathnames

### DIFF
--- a/src/no/atc/floyd/bukkit/tele/TelePlugin.java
+++ b/src/no/atc/floyd/bukkit/tele/TelePlugin.java
@@ -53,6 +53,7 @@ public class TelePlugin extends JavaPlugin implements Listener {
 
 	private File req_dir = new File(this.getDataFolder(), "requests");
 	private File loc_dir = new File(this.getDataFolder(), "locations");
+	private File warp_dir = new File(this.getDataFolder(), "warps");
 	private final long cooldown = 86400 * 1000; // Milliseconds
 	private ConcurrentHashMap<String,ConcurrentHashMap<Integer,Location>> locs = new ConcurrentHashMap<String,ConcurrentHashMap<Integer,Location>>();
     private Integer max_tpback = 1440; // Number of MINUTES to keep

--- a/src/no/atc/floyd/bukkit/tele/TelePlugin.java
+++ b/src/no/atc/floyd/bukkit/tele/TelePlugin.java
@@ -51,8 +51,8 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 public class TelePlugin extends JavaPlugin implements Listener {
     //public static Permissions Permissions = null;
 
-	private File req_dir = new File("plugins/TelePlugin/requests");
-	private File loc_dir = new File("plugins/TelePlugin/locations");
+	private File req_dir = new File(this.getDataFolder(), "requests");
+	private File loc_dir = new File(this.getDataFolder(), "locations");
 	private final long cooldown = 86400 * 1000; // Milliseconds
 	private ConcurrentHashMap<String,ConcurrentHashMap<Integer,Location>> locs = new ConcurrentHashMap<String,ConcurrentHashMap<Integer,Location>>();
     private Integer max_tpback = 1440; // Number of MINUTES to keep
@@ -661,9 +661,9 @@ public class TelePlugin extends JavaPlugin implements Listener {
           }
         }
 
-        File dir = new File(this.getDataFolder() + "/warps/");
+        File dir = new File(this.getDataFolder(), "warps");
         if (owner != null)
-          dir = new File(dir, owner + "/");
+          dir = new File(dir, owner);
 
         // List all files ending with ".loc"
         File[] warps = dir.listFiles(new FilenameFilter()
@@ -796,7 +796,7 @@ public class TelePlugin extends JavaPlugin implements Listener {
     	}
 
     	// Create request token
-    	f = new File(req_dir.getPath() + "/" + subject + "-to-" + destination + ".requested");
+    	f = new File(req_dir, subject + "-to-" + destination + ".requested");
     	if (f.exists() && f.lastModified() + cooldown > now) {
     		// Already requested so renew quietly
     		getLogger().info(subject + " renewing /tpa request to " + destination);
@@ -826,7 +826,7 @@ public class TelePlugin extends JavaPlugin implements Listener {
     	File f = null;
 
     	// Create request token
-		f = new File(req_dir.getPath() + "/" + subject + "-to-" + destination + ".requested");
+		f = new File(req_dir, subject + "-to-" + destination + ".requested");
     	f.delete();
 
     	return true;
@@ -842,11 +842,11 @@ public class TelePlugin extends JavaPlugin implements Listener {
     	}
 
     	// Delete denial token, if any
-    	f = new File(req_dir.getPath() + "/" + destination + "-to-" + subject + ".denied");
+    	f = new File(req_dir, destination + "-to-" + subject + ".denied");
     	f.delete();
 
     	// Create permission token
-    	f = new File(req_dir.getPath() + "/" + destination + "-to-" + subject + ".granted");
+    	f = new File(req_dir, destination + "-to-" + subject + ".granted");
     	if (f.exists() && f.lastModified() + cooldown > now) {
     		// Already granted so renew quietly
     		getLogger().info(subject + " renewing /tpa permission for §6" + destination);
@@ -883,15 +883,15 @@ public class TelePlugin extends JavaPlugin implements Listener {
     	}
 
     	// Delete permission token, if any
-    	f = new File(req_dir.getPath() + "/" + destination + "-to-" + subject + ".granted");
+    	f = new File(req_dir, destination + "-to-" + subject + ".granted");
     	f.delete();
 
     	// Delete request token, if any
-    	f = new File(req_dir.getPath() + "/" + destination + "-to-" + subject + ".requested");
+    	f = new File(req_dir, destination + "-to-" + subject + ".requested");
     	f.delete();
 
     	// Create denial token
-    	f = new File(req_dir.getPath() + "/" + destination + "-to-" + subject + ".denied");
+    	f = new File(req_dir, destination + "-to-" + subject + ".denied");
     	if (f.exists() && f.lastModified() + cooldown > now) {
     		// Already denied so renew quietly
     		getLogger().info(subject + " renewing /tpa denial for " + destination);
@@ -923,7 +923,7 @@ public class TelePlugin extends JavaPlugin implements Listener {
     	}
 
     	// Check for valid permission token
-    	f = new File(req_dir.getPath() + "/" + subject + "-to-" + destination + ".denied");
+    	f = new File(req_dir, subject + "-to-" + destination + ".denied");
     	if (f.exists() && f.lastModified() + cooldown > now) {
     		return true;
     	} else {
@@ -941,7 +941,7 @@ public class TelePlugin extends JavaPlugin implements Listener {
     	}
 
     	// Check for valid permission token
-    	f = new File(req_dir.getPath() + "/" + subject + "-to-" + destination + ".granted");
+    	f = new File(req_dir, subject + "-to-" + destination + ".granted");
     	if (f.exists() && f.lastModified() + cooldown > now) {
     		return true;
     	} else {
@@ -959,7 +959,7 @@ public class TelePlugin extends JavaPlugin implements Listener {
     	}
 
     	// Check for valid request token
-    	f = new File(req_dir.getPath() + "/" + subject + "-to-" + destination + ".requested");
+    	f = new File(req_dir, subject + "-to-" + destination + ".requested");
     	if (f.exists() && f.lastModified() + cooldown > now) {
     		return true;
     	} else {
@@ -1035,8 +1035,7 @@ public class TelePlugin extends JavaPlugin implements Listener {
     	Integer minute_now = (getUnixtime() / 60);
     	Integer minute_limit = minute_now - max_tpback;
     	ConcurrentHashMap<Integer,Location> playerlocs = new ConcurrentHashMap<Integer,Location>();
-    	String fname = loc_dir+"/"+pname+".dat";
-    	File file = new File(fname);
+    	File file = new File(loc_dir, pname + ".dat");
     	if (file.exists() == false) {
     		return playerlocs;
     	}
@@ -1089,9 +1088,9 @@ public class TelePlugin extends JavaPlugin implements Listener {
 			getLogger().warning("Internal error: No location data to save for player "+pname);
 			return;
 		}
-    	String fname = loc_dir+"/"+pname+".dat";
+    	File file = new File(loc_dir, pname + ".dat");
     	try {
-			FileWriter outFile = new FileWriter(fname);
+			FileWriter outFile = new FileWriter(file);
 			PrintWriter out = new PrintWriter(outFile);
 			for (Integer minute : playerlocs.keySet()) {
 				Location loc = playerlocs.get(minute);

--- a/src/no/atc/floyd/bukkit/tele/TelePlugin.java
+++ b/src/no/atc/floyd/bukkit/tele/TelePlugin.java
@@ -51,9 +51,9 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 public class TelePlugin extends JavaPlugin implements Listener {
     //public static Permissions Permissions = null;
 
-	private File req_dir = new File(this.getDataFolder(), "requests");
-	private File loc_dir = new File(this.getDataFolder(), "locations");
-	private File warp_dir = new File(this.getDataFolder(), "warps");
+	public final File req_dir = new File(this.getDataFolder(), "requests");
+	public final File loc_dir = new File(this.getDataFolder(), "locations");
+	public final File warp_dir = new File(this.getDataFolder(), "warps");
 	private final long cooldown = 86400 * 1000; // Milliseconds
 	private ConcurrentHashMap<String,ConcurrentHashMap<Integer,Location>> locs = new ConcurrentHashMap<String,ConcurrentHashMap<Integer,Location>>();
     private Integer max_tpback = 1440; // Number of MINUTES to keep

--- a/src/no/atc/floyd/bukkit/tele/Warp.java
+++ b/src/no/atc/floyd/bukkit/tele/Warp.java
@@ -73,11 +73,11 @@ public class Warp {
 	
 	public boolean exists() {
 		// Return true if the warp name can be resolved to a location
-		File f = new File(this.fname());
+		File f = this.file();
 		if (f.exists()) {
-			plugin.getLogger().finest(this.fname()+" exists");
+			plugin.getLogger().finest(f + " exists");
 		} else {
-			plugin.getLogger().finest(this.fname()+" does not exist");
+			plugin.getLogger().finest(f + " does not exist");
 		}
 		return f.exists();
 	}
@@ -147,7 +147,7 @@ public class Warp {
 		Location loaded = null;
 		String line;
 		try {
-        	BufferedReader input = new BufferedReader(new FileReader(this.fname()));
+        	BufferedReader input = new BufferedReader(new FileReader(this.file());
         	line = input.readLine();
         	input.close();
 			String[] parts = line.split(":");
@@ -198,14 +198,18 @@ public class Warp {
 		return loaded;
 	}
 
+	@Deprecated
 	public String fname() {
-		// Return the file name of this warp
+		return this.file().toString();
+	}
+	
+	public File file() {
 		if (ownername.equals("")) {
 			// Global warp point
-			return plugin.getDataFolder()+"/warps/"+pointname.toLowerCase()+".loc";
+			return new File(plugin.warp_dir, pointname.toLowerCase() + ".loc");
 		} else {
 			// Personal warp point
-			return plugin.getDataFolder()+"/warps/"+ownername.toLowerCase()+"/"+pointname.toLowerCase()+".loc";
+			return new File(new File(plugin.warp_dir, ownername.toLowerCase()), pointname.toLowerCase() + ".loc");
 		}
 	}
 	
@@ -221,15 +225,15 @@ public class Warp {
 	
 	public boolean create() {
 		// Write this warp point to disk
-		File f = new File(this.fname());
+		File f = this.file();
    		String newline = System.getProperty("line.separator");
 		try {
 			f.getParentFile().mkdirs();
 			if (f.createNewFile()) {
-	       		BufferedWriter output = new BufferedWriter(new FileWriter(this.fname()));
+	       		BufferedWriter output = new BufferedWriter(new FileWriter(f);
            		output.write( loc.getX() + ":" + loc.getY() + ":" + loc.getZ() + ":" + loc.getYaw() + ":" + loc.getPitch() + ":" + loc.getWorld().getName() + newline );
            		output.close();
-    			plugin.getLogger().finest(this.fname()+" saved");
+    			plugin.getLogger().finest(f + " saved");
 			}
 			return true;
 		} catch (IOException e) {
@@ -241,10 +245,10 @@ public class Warp {
 
 	public boolean delete() {
 		// Delete this warp point from disk
-		File f = new File(this.fname());
+		File f = this.file();
 		if (f.exists()) {
 			f.delete();
-			plugin.getLogger().finest(this.fname()+" deleted");
+			plugin.getLogger().finest(f + " deleted");
 			return true;
 		} else {
 			return false;
@@ -253,10 +257,10 @@ public class Warp {
 
 	public void touch() {
 		// Update the 'modified' time stamp of this warp point
-		File f = new File(this.fname());
+		File f = this.file();
 		if (f.exists()) {
 			f.setLastModified(System.currentTimeMillis());
-			plugin.getLogger().finest(this.fname()+" touched");
+			plugin.getLogger().finest(f + " touched");
 		}
 		return;
 	}

--- a/src/no/atc/floyd/bukkit/tele/Warp.java
+++ b/src/no/atc/floyd/bukkit/tele/Warp.java
@@ -14,7 +14,6 @@ import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 
 public class Warp {
 	
@@ -22,12 +21,12 @@ public class Warp {
 	private String pointname = "";
 	private String worldname = "";
 	private Server server = null;
-	private Plugin plugin = null;
+	private TelePlugin plugin = null;
 	private Location loc = null;
 	private Boolean global = true;
 	private String lasterror = "";
 	
-	public Warp(String name, Player p, Plugin plu) {
+	public Warp(String name, Player p, TelePlugin plu) {
 		String[] parts;
 		// Get essentials
 		plugin = plu;

--- a/src/no/atc/floyd/bukkit/tele/Warp.java
+++ b/src/no/atc/floyd/bukkit/tele/Warp.java
@@ -147,7 +147,7 @@ public class Warp {
 		Location loaded = null;
 		String line;
 		try {
-        	BufferedReader input = new BufferedReader(new FileReader(this.file());
+        	BufferedReader input = new BufferedReader(new FileReader(this.file()));
         	line = input.readLine();
         	input.close();
 			String[] parts = line.split(":");
@@ -230,7 +230,7 @@ public class Warp {
 		try {
 			f.getParentFile().mkdirs();
 			if (f.createNewFile()) {
-	       		BufferedWriter output = new BufferedWriter(new FileWriter(f);
+	       		BufferedWriter output = new BufferedWriter(new FileWriter(f));
            		output.write( loc.getX() + ":" + loc.getY() + ":" + loc.getZ() + ":" + loc.getYaw() + ":" + loc.getPitch() + ":" + loc.getWorld().getName() + newline );
            		output.close();
     			plugin.getLogger().finest(f + " saved");


### PR DESCRIPTION
Various pathname improvements:
- Proper seperators
- Path constants
- Use `java.io.File` instead of `java.lang.String` for pathnames
